### PR TITLE
CI: Try to use 3.107, extend version name pattern, allow osx failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,3 +32,11 @@ matrix:
   - rvm: rbx-3
     env: RBX_RUBY_COMPAT=2.3.1 RBX_VERSION=3.107
     os: osx
+  allow_failures:
+  - rvm: rbx-3.107
+    env: RBX_RUBY_COMPAT=2.3.1 RBX_VERSION=3.107
+    os: osx
+  - rvm: rbx-3
+    env: RBX_RUBY_COMPAT=2.3.1 RBX_VERSION=3.107
+    os: osx
+      

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,15 +26,9 @@ matrix:
   - rvm: rbx-3
     env: RBX_RUBY_COMPAT=2.3.1 RBX_VERSION=3.107
     os: linux
-  - rvm: rbx
-    env: RBX_RUBY_COMPAT=2.3.1 RBX_VERSION=3.107
-    os: linux
   - rvm: rbx-3.107
     env: RBX_RUBY_COMPAT=2.3.1 RBX_VERSION=3.107
     os: osx
   - rvm: rbx-3
-    env: RBX_RUBY_COMPAT=2.3.1 RBX_VERSION=3.107
-    os: osx
-  - rvm: rbx
     env: RBX_RUBY_COMPAT=2.3.1 RBX_VERSION=3.107
     os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: ruby
-sudo: required
+
 dist: trusty
 script: rake
+
 notifications:
   email: false
   webhooks:
@@ -19,21 +20,21 @@ matrix:
   exclude:
   - rvm: 2.0.0
   include:
-  - rvm: rbx-3.100
-    env: RBX_RUBY_COMPAT=2.3.1 RBX_VERSION=3.100
+  - rvm: rbx-3.107
+    env: RBX_RUBY_COMPAT=2.3.1 RBX_VERSION=3.107
     os: linux
   - rvm: rbx-3
-    env: RBX_RUBY_COMPAT=2.3.1 RBX_VERSION=3.100
+    env: RBX_RUBY_COMPAT=2.3.1 RBX_VERSION=3.107
     os: linux
   - rvm: rbx
-    env: RBX_RUBY_COMPAT=2.3.1 RBX_VERSION=3.100
+    env: RBX_RUBY_COMPAT=2.3.1 RBX_VERSION=3.107
     os: linux
-  - rvm: rbx-3.100
-    env: RBX_RUBY_COMPAT=2.3.1 RBX_VERSION=3.100
+  - rvm: rbx-3.107
+    env: RBX_RUBY_COMPAT=2.3.1 RBX_VERSION=3.107
     os: osx
   - rvm: rbx-3
-    env: RBX_RUBY_COMPAT=2.3.1 RBX_VERSION=3.100
+    env: RBX_RUBY_COMPAT=2.3.1 RBX_VERSION=3.107
     os: osx
   - rvm: rbx
-    env: RBX_RUBY_COMPAT=2.3.1 RBX_VERSION=3.100
+    env: RBX_RUBY_COMPAT=2.3.1 RBX_VERSION=3.107
     os: osx

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
 task :default do
-  re = /^rubinius\s(\d+\.\d+(\.\d+)?)(\.c\d+)?\s\((\d+\.\d+\.\d+)\s[0-9a-f]{8}\s\d{4}-\d{2}-\d{2}\s\d+\.\d+(\.\d+)?(\sJ?I?C?D?)?\)\s\[[^\]]+\]$/
+  re = /^rubinius\s(\d+\.\d+(\.\d+)?)(\.c\d+)?\s\((\d+\.\d+\.\d+)\s[0-9a-f]{8}\s\d{4}-\d{2}-\d{2}\s\d+\.\d+(\.\d+)?(?:git\-[0-9a-f]{7})?(\sJ?I?C?D?)?\)\s\[[^\]]+\]$/
 
   rbx_version = `rbx -v`.chomp
   m = re.match rbx_version


### PR DESCRIPTION
This PR is an experimental run with 3.107 (to explore what happens - and what it takes to get to green).

## Steps taken

- Set the version from 3.100 to 3.107
- Accept more version output strings in the Rake task **Update**: This made Linux pass.
- `rvm` no longer lists `rbx` as a known shorthand name: https://github.com/rvm/rvm/blob/master/config/known#L25 - this PR drops that name from the matrix
- Consider adding `rbx-head` to matrix

## Arguable - please discuss

- Matrix: allow_failures for `osx` - they 404 as there seem to be no published Rubies gettable via the `--binary` option