### PR TITLE
CI: Drop 2.0.0 settings, name each build job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,12 @@ notifications:
 matrix:
   include:
     - rvm: rbx-4
-      env: RBX_RUBY_COMPAT=2.3.1 RBX_VERSION=4.4
+      env: RBX_RUBY_COMPAT=2.3.1 RBX_VERSION=4.15
       os: linux
       name: Rubinius 4 on Linux
       dist: trusty
     - rvm: rbx-4
-      env: RBX_RUBY_COMPAT=2.3.1 RBX_VERSION=4.4
+      env: RBX_RUBY_COMPAT=2.3.1 RBX_VERSION=4.15
       os: osx
       name: Rubinius 4 on macOS
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,22 +9,16 @@ notifications:
     on_success: change
     on_failure: always
     on_start: always
-os:
-- linux
-- osx
-rvm:
-- 2.0.0
+
 matrix:
-  exclude:
-  - rvm: 2.0.0
   include:
-  - rvm: rbx-4
-    env: RBX_RUBY_COMPAT=2.3.1 RBX_VERSION=4.4
-    os: linux
-  - rvm: rbx-4
-    env: RBX_RUBY_COMPAT=2.3.1 RBX_VERSION=4.4
-    os: osx
+    - rvm: rbx-4
+      env: RBX_RUBY_COMPAT=2.3.1 RBX_VERSION=4.4
+      os: linux
+      name: Rubinius 4 on Linux
+    - rvm: rbx-4
+      env: RBX_RUBY_COMPAT=2.3.1 RBX_VERSION=4.4
+      os: osx
+      name: Rubinius 4 on macOS
   allow_failures:
-  - rvm: rbx-4
-    env: RBX_RUBY_COMPAT=2.3.1 RBX_VERSION=4.4
-    os: osx
+    - name: Rubinius 4 on macOS

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,12 @@ notifications:
 matrix:
   include:
     - rvm: rbx-4
-      env: RBX_RUBY_COMPAT=2.3.1 RBX_VERSION=4.15
+      env: RBX_RUBY_COMPAT=10.0 RBX_VERSION=4.15
       os: linux
       name: Rubinius 4 on Linux
       dist: trusty
     - rvm: rbx-4
-      env: RBX_RUBY_COMPAT=2.3.1 RBX_VERSION=4.15
+      env: RBX_RUBY_COMPAT=10.0 RBX_VERSION=4.15
       os: osx
       name: Rubinius 4 on macOS
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ matrix:
       env: RBX_RUBY_COMPAT=2.3.1 RBX_VERSION=4.4
       os: linux
       name: Rubinius 4 on Linux
+      dist: trusty
     - rvm: rbx-4
       env: RBX_RUBY_COMPAT=2.3.1 RBX_VERSION=4.4
       os: osx

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
 task :default do
-  re = /^rubinius\s(\d+\.\d+(\.\d+)?)(\.c\d+)?\s\((\d+\.\d+\.\d+)\s[0-9a-f]{8}\s\d{4}-\d{2}-\d{2}\s\d+\.\d+(\.\d+)?(?:git\-[0-9a-f]{7})?(\sJ?I?C?D?)?\)\s\[[^\]]+\]$/
+  re = /^rubinius\s(\d+\.\d+(\.\d+)?)(\.c\d+)?\s\((\d+\.\d+(?:\.\d+)?)\s[0-9a-f]{8}\s\d{4}-\d{2}-\d{2}\s\d+\.\d+(\.\d+)?(?:git\-[0-9a-f]{7})?(\sJ?I?C?D?)?\)\s\[[^\]]+\]$/
 
   rbx_version = `rbx -v`.chomp
   m = re.match rbx_version


### PR DESCRIPTION
TL;DR: an attempt to get to green for this repo.

- Add `name` property to matrix combinations. This allows for easier scanning of the `allow_failures` section
- Add `dist: trusty` - to allow rvm to continue past the step where gemsets failed to be created
- Changed the check-for-Rubinius versions regex to support the current output
- Changed the expectation from `2.3.1` ➡️  `10.0` ❓ ❓ ⚠️ ❓ ❓ Are there perhaps any new ways of learning the "supported version" or is `10.0` the value to check for? **Answer**: 10.0 _is_ the value to check for.

---

## Details

On a lark, I added `dist: trusty`. That made things pass far enough that Rubinius could express its `--version` output.

Then, the regex which checked it didn't like the 10.0 (expecting a triple of numbers, like `10.0.0`). I added a non-capturing regex group to also accept 10.0. `Rakefile` has the regex.

Now, it seemed that the output of `rbx-4` no longer has a value for "Ruby version compatibility" in its first line of output. Should it?

Example failure:

```
Rubinius version output:
  rubinius 4.15 (10.0 21e83c45 2020-02-02 5.0.0git-929163d) [x86_64-linux-gnu]
did not match:
  /^rubinius\s(\d+\.\d+(\.\d+)?)(\.c\d+)?\s\((\d+\.\d+\.\d+)\s[0-9a-f]{8}\s\d{4}-\d{2}-\d{2}\s\d+\.\d+(\.\d+)?(?:git\-[0-9a-f]{7})?(\sJ?I?C?D?)?\)\s\[[^\]]+\]$/
```

